### PR TITLE
Fix SDK path configuration - SDK extracts to ~/bin directly

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,46 +29,24 @@ jobs:
         echo "Downloading SDK: $SDK"
 
         # Download and extract SDK
+        # Note: The SDK zip extracts directly to ~/bin/, ~/lib/, etc.
         wget -q -O ciq.zip $GMNDL/$SDK
         unzip -q ciq.zip -d ~/
 
-        # Extract version directory name (remove .zip extension)
-        SDK_DIR=$(basename "$SDK" .zip)
-        echo "SDK Directory: $SDK_DIR"
-
-        # Debug: List what was extracted
-        echo "Contents of home directory:"
-        ls -la ~/ | grep connectiq || echo "No connectiq directory found"
-
-        # Check if bin directory exists
-        if [ -d "$HOME/$SDK_DIR/bin" ]; then
-          echo "Found bin directory at: $HOME/$SDK_DIR/bin"
-          ls -la "$HOME/$SDK_DIR/bin" | head -20
-        else
-          echo "ERROR: bin directory not found at $HOME/$SDK_DIR/bin"
-          echo "Directory structure:"
-          find ~/ -maxdepth 3 -name "monkeyc" -o -name "bin" 2>/dev/null
-        fi
+        # Verify extraction
+        echo "SDK extracted to home directory"
+        ls -la ~/bin/monkeyc || echo "ERROR: monkeyc not found"
 
         # Set environment variables
-        echo "CONNECTIQ_SDK_HOME=$HOME/$SDK_DIR" >> $GITHUB_ENV
-        echo "$HOME/$SDK_DIR/bin" >> $GITHUB_PATH
+        # The SDK extracts to $HOME/bin, $HOME/lib, etc.
+        echo "CONNECTIQ_SDK_HOME=$HOME" >> $GITHUB_ENV
+        echo "$HOME/bin" >> $GITHUB_PATH
 
     - name: Verify SDK Installation
       run: |
-        echo "PATH: $PATH"
-        echo "CONNECTIQ_SDK_HOME: $CONNECTIQ_SDK_HOME"
-        echo "Checking for monkeyc:"
-        which monkeyc || echo "monkeyc not in PATH"
-        ls -la "$CONNECTIQ_SDK_HOME/bin/monkeyc" || echo "monkeyc not found at expected location"
-
-        # Try to run monkeyc with full path
-        if [ -f "$CONNECTIQ_SDK_HOME/bin/monkeyc" ]; then
-          "$CONNECTIQ_SDK_HOME/bin/monkeyc" --version
-        else
-          echo "ERROR: monkeyc binary not found"
-          exit 1
-        fi
+        echo "Verifying SDK installation..."
+        which monkeyc
+        monkeyc --version
 
     - name: Build Main Application
       run: |


### PR DESCRIPTION
Root cause identified:
- The SDK zip extracts directly to ~/bin/, ~/lib/, etc.
- Previous code assumed SDK would extract to a versioned subdirectory
- Debug output showed monkeyc was at /home/runner/bin/monkeyc

Changes:
- Set CONNECTIQ_SDK_HOME to $HOME (not $HOME/$SDK_DIR)
- Add $HOME/bin to PATH (where monkeyc actually lives)
- Remove incorrect directory structure assumptions
- Simplify verification step

This should now allow monkeyc to be found and executed.