### PR TITLE
Fix device ID from fenix8_51mm to fenix8solar51mm

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,7 +55,7 @@ jobs:
         monkeyc \
           -o build/meshtastic.prg \
           -f monkey.jungle \
-          -d fenix8_51mm \
+          -d fenix8solar51mm \
           -w
 
     - name: Build Comprehensive Tests
@@ -64,7 +64,7 @@ jobs:
         monkeyc \
           -o build/comprehensive-test.prg \
           -f comprehensive-test.jungle \
-          -d fenix8_51mm \
+          -d fenix8solar51mm \
           -w
 
     - name: Run Tests in Simulator

--- a/PHASE1_COMPLETE.md
+++ b/PHASE1_COMPLETE.md
@@ -200,7 +200,7 @@ Phase 1 delivers a **working messaging foundation**. Phase 2 will add:
 ### Run Unit Tests
 ```bash
 # Compile and run tests in simulator
-monkeyc -f comprehensive-test.jungle -d fenix8_51mm -o build/test.prg
+monkeyc -f comprehensive-test.jungle -d fenix8solar51mm -o build/test.prg
 ```
 
 ### Test on Hardware

--- a/TESTING.md
+++ b/TESTING.md
@@ -32,10 +32,10 @@ This document describes how to test the Meshtastic Garmin Watch application.
 
 ```bash
 # Build main application
-monkeyc -o build/meshtastic.prg -f monkey.jungle -d fenix8_51mm -w
+monkeyc -o build/meshtastic.prg -f monkey.jungle -d fenix8solar51mm -w
 
 # Build and run comprehensive tests
-monkeyc -o build/test.prg -f comprehensive-test.jungle -d fenix8_51mm -w
+monkeyc -o build/test.prg -f comprehensive-test.jungle -d fenix8solar51mm -w
 connectiq # Launch simulator
 # Load build/test.prg in simulator
 ```
@@ -43,7 +43,7 @@ connectiq # Launch simulator
 ### VS Code Testing
 
 1. Open project in VS Code
-2. Select build target (fenix8_51mm)
+2. Select build target (fenix8solar51mm)
 3. Press F5 to build and run
 4. Switch jungle files in settings for different test suites
 
@@ -75,7 +75,7 @@ Automated testing runs on every push and PR:
 1. **Deploy to Watch**
    ```bash
    # Build for device
-   monkeyc -o build/meshtastic.prg -f monkey.jungle -d fenix8_51mm
+   monkeyc -o build/meshtastic.prg -f monkey.jungle -d fenix8solar51mm
 
    # Deploy via WiFi or USB
    # Use Garmin Express or Connect IQ app
@@ -233,7 +233,7 @@ System.println("Memory: " + monitor.getMemoryStatus());
 ### Pre-Commit
 ```bash
 # Always build before committing
-monkeyc -o build/meshtastic.prg -f monkey.jungle -d fenix8_51mm -w
+monkeyc -o build/meshtastic.prg -f monkey.jungle -d fenix8solar51mm -w
 ```
 
 ### Pre-Release


### PR DESCRIPTION
The workflow was using an invalid device ID 'fenix8_51mm' which caused the monkeyc compiler to fail. The correct device ID is 'fenix8solar51mm' as specified in manifest.xml.

Changes:
- Updated workflow to use fenix8solar51mm for both main app and tests
- Fixed TESTING.md to use correct device ID consistently
- Fixed PHASE1_COMPLETE.md to use correct device ID

This aligns with the device ID already specified in:
- manifest.xml
- test-manifest.xml
- hardware-test-manifest.xml
- All readme.md examples

The build should now succeed.