### PR TITLE
Complete SDK build fix with bundled fenix8solar51mm device files

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,8 @@ jobs:
         monkeyc \
           -o build/meshtastic.prg \
           -f monkey.jungle \
-          -d fenix7 \
+          -d fenix8solar51mm \
+          -u .connectiq/Devices \
           -w
 
     - name: Build Comprehensive Tests
@@ -76,7 +77,8 @@ jobs:
         monkeyc \
           -o build/comprehensive-test.prg \
           -f comprehensive-test.jungle \
-          -d fenix7 \
+          -d fenix8solar51mm \
+          -u .connectiq/Devices \
           -w
 
     - name: Run Tests in Simulator

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Meshtastic client implementation for Garmin wearables using Connect IQ SDK.
 
 - **Garmin Connect IQ SDK** 8.3.0 or higher
 - **Developer key** for signing builds
-- **Garmin device** with BLE support (Fenix 7/7S/7X or compatible) or simulator
+- **Garmin device** with BLE support (Fenix 8 Solar recommended) or simulator
 
 ## Setup
 
@@ -20,22 +20,22 @@ A Meshtastic client implementation for Garmin wearables using Connect IQ SDK.
 
 Build the main application:
 ```bash
-monkeyc -f monkey.jungle -d fenix7 -o build/meshtastic.prg -y developer_key
+monkeyc -f monkey.jungle -d fenix8solar51mm -o build/meshtastic.prg -y developer_key
 ```
 
 Build the interactive simulator test:
 ```bash
-monkeyc -f interactive-test.jungle -d fenix7 -o build/interactive-simulator.prg -y developer_key
+monkeyc -f interactive-test.jungle -d fenix8solar51mm -o build/interactive-simulator.prg -y developer_key
 ```
 
 Build the protobuf test:
 ```bash
-monkeyc -f proto-test.jungle -d fenix7 -o build/prototest.prg -y developer_key
+monkeyc -f proto-test.jungle -d fenix8solar51mm -o build/prototest.prg -y developer_key
 ```
 
 Build the comprehensive test:
 ```bash
-monkeyc -f comprehensive-test.jungle -d fenix7 -o build/comprehensive.prg -y developer_key
+monkeyc -f comprehensive-test.jungle -d fenix8solar51mm -o build/comprehensive.prg -y developer_key
 ```
 
 ## Run

--- a/manifest.xml
+++ b/manifest.xml
@@ -3,9 +3,7 @@
 <iq:manifest xmlns:iq="http://www.garmin.com/xml/connectiq" version="3">
     <iq:application entry="FixedSimpleTestApp" id="baa15afcc2a0446cfeb1c8d504fd65aa" launcherIcon="@Drawables.LauncherIcon" minSdkVersion="3.1.0" name="@Strings.AppName" type="watch-app" version="1.0.0">
         <iq:products>
-            <iq:product id="fenix7"/>
-            <iq:product id="fenix7s"/>
-            <iq:product id="fenix7x"/>
+            <iq:product id="fenix8solar51mm"/>
         </iq:products>
         <iq:permissions>
             <iq:uses-permission id="BluetoothLowEnergy"/>


### PR DESCRIPTION
Updated workflow, manifest, and README to use fenix8solar51mm with bundled device files from .connectiq/Devices directory.

Changes:
- Workflow now uses fenix8solar51mm with -u .connectiq/Devices flag
- This eliminates the need for Garmin authentication in CI
- Manifest reverted to fenix8solar51mm target device
- README updated with correct build commands for fenix8solar51mm

The bundled compiler.json and simulator.json files allow CI builds to work without downloading devices via SDK Manager.