### PR TITLE
Add developer key generation for CI builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,6 +58,12 @@ jobs:
         echo "Device files installed:"
         ls -la $HOME/.Garmin/ConnectIQ/Devices/fenix8solar51mm/
 
+    - name: Generate Developer Key
+      run: |
+        echo "Generating temporary developer key for CI builds..."
+        openssl genrsa -out developer_key 4096 2>/dev/null
+        echo "Developer key generated"
+
     - name: Build Main Application
       run: |
         echo "Building main application..."
@@ -66,6 +72,7 @@ jobs:
           -o build/meshtastic.prg \
           -f monkey.jungle \
           -d fenix8solar51mm \
+          -y developer_key \
           -w
 
     - name: Build Comprehensive Tests
@@ -75,6 +82,7 @@ jobs:
           -o build/comprehensive-test.prg \
           -f comprehensive-test.jungle \
           -d fenix8solar51mm \
+          -y developer_key \
           -w
 
     - name: Run Tests in Simulator


### PR DESCRIPTION
Added step to generate temporary RSA developer key for signing builds in CI environment. Updated both build commands to use the key.

Changes:
- Generate 4096-bit RSA key before building
- Add -y developer_key flag to monkeyc commands
- Key is only used for CI validation, not production deployment

This completes the CI build fix - builds should now succeed!