### PR TITLE
Fix developer key format - convert to PKCS8 DER

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,8 +61,11 @@ jobs:
     - name: Generate Developer Key
       run: |
         echo "Generating temporary developer key for CI builds..."
-        openssl genrsa -out developer_key 4096 2>/dev/null
-        echo "Developer key generated"
+        # Generate RSA key and convert to PKCS8 DER format (required by Garmin SDK)
+        openssl genrsa -out developer_key.pem 4096 2>/dev/null
+        openssl pkcs8 -topk8 -inform PEM -outform DER -in developer_key.pem -out developer_key -nocrypt
+        rm developer_key.pem
+        echo "Developer key generated in PKCS8 format"
 
     - name: Build Main Application
       run: |


### PR DESCRIPTION
The Garmin SDK requires keys in PKCS8 DER format, not PEM format.

Changes:
- Generate RSA key in PEM format first
- Convert to PKCS8 DER format using openssl pkcs8
- Clean up temporary PEM file

This fixes the "invalid key format" error in CI builds.