### PR TITLE
Fix compilation errors - update entry point and API compatibility

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<!-- Connect IQ manifest for ProtoBuf library testing -->
+<!-- Connect IQ manifest for Meshtastic Garmin Client -->
 <iq:manifest xmlns:iq="http://www.garmin.com/xml/connectiq" version="3">
-    <iq:application entry="FixedSimpleTestApp" id="baa15afcc2a0446cfeb1c8d504fd65aa" launcherIcon="@Drawables.LauncherIcon" minSdkVersion="3.1.0" name="@Strings.AppName" type="watch-app" version="1.0.0">
+    <iq:application entry="MeshtasticApp" id="baa15afcc2a0446cfeb1c8d504fd65aa" launcherIcon="@Drawables.LauncherIcon" minSdkVersion="5.0.0" name="@Strings.AppName" type="watch-app" version="1.0.0">
         <iq:products>
             <iq:product id="fenix8solar51mm"/>
         </iq:products>

--- a/src/views/CustomMessageView.mc
+++ b/src/views/CustomMessageView.mc
@@ -207,12 +207,6 @@ class CustomMessageViewDelegate extends WatchUi.BehaviorDelegate {
 
     function showTextPicker() {
         // Use TextPicker for character-by-character input
-        var options = {
-            :title => "Enter Message",
-            :confirmLabel => "OK",
-            :cancelLabel => "Cancel"
-        };
-
         var textPicker = new WatchUi.TextPicker("");
         WatchUi.pushView(textPicker, new TextPickerDelegate(_view), WatchUi.SLIDE_UP);
     }

--- a/src/views/PinEntryView.mc
+++ b/src/views/PinEntryView.mc
@@ -122,7 +122,7 @@ class PinEntryViewDelegate extends WatchUi.BehaviorDelegate {
 
     function onSelect() {
         // Show number picker for digit entry
-        var picker = new WatchUi.NumberPicker(WatchUi.NUMBER_PICKER_NUMBER);
+        var picker = new WatchUi.NumberPicker();
         WatchUi.pushView(picker, new NumberPickerDelegate(_view), WatchUi.SLIDE_UP);
         return true;
     }


### PR DESCRIPTION
Fixed multiple compilation errors to enable successful builds:

1. Manifest entry point: Changed from "FixedSimpleTestApp" to "MeshtasticApp"
2. API version: Increased minSdkVersion from 3.1.0 to 5.0.0 for BLE pairing APIs
3. NumberPicker: Removed unsupported NUMBER_PICKER_NUMBER parameter
4. Code cleanup: Removed unused 'options' variable in CustomMessageView

These changes fix all compilation errors while maintaining compatibility with fenix8solar51mm (API 5.2.0).